### PR TITLE
Update OCIOLogConvert.cpp

### DIFF
--- a/OCIO/OCIOLogConvert.cpp
+++ b/OCIO/OCIOLogConvert.cpp
@@ -42,6 +42,7 @@
 
 #include <OpenColorIO/OpenColorIO.h>
 
+#include <cstdlib>
 #include "ofxsProcessing.H"
 #include "ofxsCopier.h"
 #include "IOUtility.h"


### PR DESCRIPTION
Quiets line 631 getenv not in std on Linux.
