### PR TITLE
Git submodule update -r option is not recursive

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To fetch the latest sources from github, execute the following commands:
 
     git clone https://github.com/MrKepzie/openfx-io.git
     cd openfx-io
-    git submodule update -i -r
+    git submodule update -i --recursive
 
 In order to get a specific tag, corresponding to a source release, do `git tag -l`
 to get the list of tags, and then `git checkout tags/<tag_name>`


### PR DESCRIPTION
Just a minor README build instructions error, not that big of a deal. If I knew git better I would not have been stuck for a bit trying to find where to get/put tinydir.  :smile: 